### PR TITLE
Fix column rendering and persistence

### DIFF
--- a/apps/web/src/app/Board.test.tsx
+++ b/apps/web/src/app/Board.test.tsx
@@ -71,7 +71,8 @@ vi.mock('@liveblocks/react', () => {
       return selector({ columns: store.get('columns') })
     },
     useRoom: () => ({
-      subscribe: (_type: string, cb: () => void) => {
+      getStorage: () => Promise.resolve(store),
+      subscribe: (_node: unknown, cb: () => void) => {
         listeners.add(cb)
         return () => listeners.delete(cb)
       },

--- a/apps/web/src/app/Board.test.tsx
+++ b/apps/web/src/app/Board.test.tsx
@@ -71,7 +71,7 @@ vi.mock('@liveblocks/react', () => {
       return selector({ columns: store.get('columns') })
     },
     useRoom: () => ({
-      subscribe: (_target: unknown, cb: () => void) => {
+      subscribe: (_type: string, cb: () => void) => {
         listeners.add(cb)
         return () => listeners.delete(cb)
       },
@@ -84,8 +84,8 @@ vi.mock('@liveblocks/react', () => {
 // Mock supabase client
 vi.mock('../lib/supabase', () => {
   const upsert = vi.fn().mockResolvedValue({})
-  const single = vi.fn().mockResolvedValue({ data: null })
-  const eq = vi.fn(() => ({ single }))
+  const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null })
+  const eq = vi.fn(() => ({ maybeSingle }))
   const select = vi.fn(() => ({ eq }))
   return {
     supabase: { from: vi.fn(() => ({ select, upsert })) },

--- a/apps/web/src/app/Board.test.tsx
+++ b/apps/web/src/app/Board.test.tsx
@@ -34,6 +34,9 @@ const { listeners, MockLiveObject, MockLiveList } = vi.hoisted(() => {
     get(index: number) {
       return this.items[index]
     }
+    map<U>(fn: (item: T, index: number) => U): U[] {
+      return this.items.map(fn)
+    }
   }
   return { listeners, MockLiveObject, MockLiveList }
 })
@@ -61,17 +64,17 @@ vi.mock('@liveblocks/react', () => {
       }
       return children
     },
-    useStorage: <T,>(selector: (root: { columns?: InstanceType<typeof MockLiveList> }) => T) => {
+    useStorage: <T,>(selector: (root: unknown) => T) => {
       const [, force] = React.useReducer((x: number) => x + 1, 0)
       React.useEffect(() => {
         const l = () => force()
         listeners.add(l)
         return () => listeners.delete(l)
       }, [])
-      return selector({ columns: store.get('columns') })
+      return selector(store as unknown)
     },
     useRoom: () => ({
-      getStorage: () => Promise.resolve(store),
+      getStorage: () => Promise.resolve({ root: store }),
       subscribe: (_node: unknown, cb: () => void) => {
         listeners.add(cb)
         return () => listeners.delete(cb)

--- a/apps/web/src/app/Board.test.tsx
+++ b/apps/web/src/app/Board.test.tsx
@@ -61,14 +61,14 @@ vi.mock('@liveblocks/react', () => {
       }
       return children
     },
-    useStorageRoot: () => {
+    useStorage: <T,>(selector: (root: { columns?: InstanceType<typeof MockLiveList> }) => T) => {
       const [, force] = React.useReducer((x: number) => x + 1, 0)
       React.useEffect(() => {
         const l = () => force()
         listeners.add(l)
         return () => listeners.delete(l)
       }, [])
-      return [store]
+      return selector({ columns: store.get('columns') })
     },
     useRoom: () => ({
       subscribe: (_target: unknown, cb: () => void) => {

--- a/apps/web/src/app/Board.tsx
+++ b/apps/web/src/app/Board.tsx
@@ -5,7 +5,7 @@ import {
   useMyPresence,
   useOthers,
   useRoom,
-  useStorageRoot,
+  useStorage,
 } from '@liveblocks/react'
 import { useEffect, type ChangeEvent } from 'react'
 import { useParams } from 'react-router-dom'
@@ -15,15 +15,9 @@ type Note = LiveObject<{ id: string; text: string }>
 type Column = LiveObject<{ id: string; title: string; notes: LiveList<Note> }>
 
 function BoardContent({ boardId }: { boardId: string }) {
-  const [root] = useStorageRoot()
-  const storage = root as LiveObject<{ columns?: LiveList<Column> }> | null
-  const columns = storage?.get('columns') as LiveList<Column> | undefined
-
-  useEffect(() => {
-    if (storage && !columns) {
-      storage.set('columns', new LiveList<Column>([]))
-    }
-  }, [storage, columns])
+  const columns = useStorage<LiveList<Column> | undefined>(
+    (root) => (root as { columns?: LiveList<Column> }).columns
+  )
   const room = useRoom()
   const [, updateMyPresence] = useMyPresence()
   const others = useOthers()

--- a/apps/web/src/app/Board.tsx
+++ b/apps/web/src/app/Board.tsx
@@ -15,8 +15,8 @@ type Note = LiveObject<{ id: string; text: string }>
 type Column = LiveObject<{ id: string; title: string; notes: LiveList<Note> }>
 
 function BoardContent({ boardId }: { boardId: string }) {
-  const columns = useStorage<LiveList<Column> | undefined>(
-    (root) => (root as { columns?: LiveList<Column> }).columns
+  const columns = useStorage<LiveList<Column>>((root) =>
+    (root as unknown as LiveObject<any>).get('columns')
   )
   const room = useRoom()
   const [, updateMyPresence] = useMyPresence()
@@ -123,35 +123,31 @@ function BoardContent({ boardId }: { boardId: string }) {
         </button>
       </div>
       <div className="flex gap-4 overflow-x-auto">
-        {Array.from({ length: columns.length }).map((_, i) => {
-          const column = columns.get(i)!
+        {columns.map((column) => {
           const notes = column.get('notes')
           return (
             <div
               key={column.get('id')}
               className="flex w-64 flex-shrink-0 flex-col rounded bg-gray-100 p-2"
             >
-                <input
-                  className="mb-2 w-full rounded border p-1"
-                  value={column.get('title')}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                    column.set('title', e.target.value)
-                  }
-                />
+              <input
+                className="mb-2 w-full rounded border p-1"
+                value={column.get('title')}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  column.set('title', e.target.value)
+                }
+              />
               <div className="flex flex-1 flex-col gap-2">
-                  {Array.from({ length: notes.length }).map((_, j) => {
-                    const note = notes.get(j)!
-                    return (
-                      <textarea
-                        key={note.get('id')}
-                        className="w-full rounded bg-yellow-200 p-2"
-                        value={note.get('text')}
-                        onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-                          note.set('text', e.target.value)
-                        }
-                      />
-                    )
-                  })}
+                {notes.map((note) => (
+                  <textarea
+                    key={note.get('id')}
+                    className="w-full rounded bg-yellow-200 p-2"
+                    value={note.get('text')}
+                    onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                      note.set('text', e.target.value)
+                    }
+                  />
+                ))}
               </div>
               <button
                 onClick={() => addNote(column)}
@@ -162,12 +158,12 @@ function BoardContent({ boardId }: { boardId: string }) {
             </div>
           )
         })}
-          <button
-            onClick={addColumn}
-            className="w-64 flex-shrink-0 rounded border-2 border-dashed p-2"
-          >
-            + Column
-          </button>
+        <button
+          onClick={addColumn}
+          className="w-64 flex-shrink-0 rounded border-2 border-dashed p-2"
+        >
+          + Column
+        </button>
       </div>
       <div className="text-sm">
         Online: {others.map((o) => o.presence.nickname).join(', ') || 'just you'}

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "installCommand": "cd apps/web && npm install",
   "buildCommand": "cd apps/web && npm run build",
   "devCommand": "cd apps/web && npm run dev",
-  "outputDirectory": "apps/web/dist"
+  "outputDirectory": "apps/web/dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Summary
- use reactive `useStorage` to display and persist board columns
- update tests for new storage hook

## Testing
- `npm --prefix apps/web test`
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build` *(fails: Cannot find module '@tailwindcss/postcss')*


------
https://chatgpt.com/codex/tasks/task_e_68a880ee8b908322bcb9b2a98d03f1c8